### PR TITLE
Added support for Objective-C

### DIFF
--- a/Sources/BackgroundEffect.swift
+++ b/Sources/BackgroundEffect.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol BackgroundEffect {
+@objc public protocol BackgroundEffect {
     var color: UIColor? { get set }
     var alpha: CGFloat { get set }
     var target: BackgroundTarget { get }
@@ -21,12 +21,12 @@ public protocol BackgroundEffect {
 ///
 /// - targetViewController: add background view to target viewcontroller
 /// - presentingViewController: add background view to target viewcontroller's presenting viewcontroller
-public enum BackgroundTarget {
+@objc public enum BackgroundTarget : NSInteger {
     case targetViewController
     case presentingViewController
 }
 
-public struct ShadowEffect: BackgroundEffect {
+@objc public class ShadowEffect: NSObject, BackgroundEffect {
     public var color: UIColor?
     public var alpha: CGFloat
     public var target: BackgroundTarget = .targetViewController
@@ -51,7 +51,7 @@ public struct ShadowEffect: BackgroundEffect {
 }
 
 @available(iOS, introduced: 9.0)
-public struct BlurEffect: BackgroundEffect {
+@objc public class BlurEffect: NSObject, BackgroundEffect {
     public var color: UIColor?
     public var alpha: CGFloat
     public var blurRadius: CGFloat

--- a/Sources/CustomBlurView.swift
+++ b/Sources/CustomBlurView.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 @available(iOS 9.0, *)
-class CustomBlurView: UIVisualEffectView {
+@objc class CustomBlurView: UIVisualEffectView {
     
     private enum PrivateKey: String {
         case blurRadius = "blurRadius"

--- a/Sources/EdgeShadow.swift
+++ b/Sources/EdgeShadow.swift
@@ -9,7 +9,20 @@
 import Foundation
 import UIKit
 
-public struct EdgeShadow {
+@objc public class EdgeShadow : NSObject {
+    
+    public init(opacity: Float, radius: CGFloat, color: UIColor, offset : CGSize){
+        
+        super.init()
+
+        self.opacity = opacity
+        self.radius = radius
+        self.color = color
+        self.offset = offset
+        
+        
+    }
+    
     static let `default` = EdgeShadow(
         opacity: 0.5, radius: 5.0, color: .black, offset: CGSize(width: 0.0, height: -5.0)
     )

--- a/Sources/PullToDismiss.swift
+++ b/Sources/PullToDismiss.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-open class PullToDismiss: NSObject {
+@objc open class PullToDismiss: NSObject {
 
     public struct Defaults {
         private init() {}

--- a/Sources/ScrollViewDelegateProxy.swift
+++ b/Sources/ScrollViewDelegateProxy.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-class ScrollViewDelegateProxy: DelegateProxy, UIScrollViewDelegate {
+@objc class ScrollViewDelegateProxy: DelegateProxy, UIScrollViewDelegate {
     @nonobjc convenience init(delegates: [UIScrollViewDelegate]) {
         self.init(__delegates: delegates)
     }

--- a/Sources/UIView+EdgeShadow.swift
+++ b/Sources/UIView+EdgeShadow.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-extension UIView {
+public extension UIView {
     func applyEdgeShadow(_ shadow: EdgeShadow?) {
         guard let shadow = shadow else {
             detachEdgeShadow()

--- a/Sources/Unavailable.swift
+++ b/Sources/Unavailable.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension PullToDismiss {
+public extension PullToDismiss {
     @available(*, unavailable, renamed: "delegate")
     public weak var delegateProxy: AnyObject? {
         fatalError("\(#function) is no longer available")


### PR DESCRIPTION
Added Objective-C compatibility. Tested in a live production app and it works without any issues. Structs are now classes inheriting from NSObject, and extensions are public. I don't believe this will cause any issues with existing swift integrations, but I'd be happy to look into this further if that is in fact the case.
